### PR TITLE
Support light and dark mode design

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@ GNU Affero General Public License for more details.
 		flex-direction: column;
 		justify-content: center;
 		align-items: center;
-		background: #191b22;
+		background: #d9dce6;
 		background-size: cover;
 		background-position: 50% 50%;
 		line-height: 120%;
@@ -172,7 +172,7 @@ GNU Affero General Public License for more details.
 		color: white;
 	}
 	footer {
-		color: #aaa;
+		color: #1a1a1a;
 		padding: 1em;
 		text-align: center;
 	}
@@ -205,6 +205,14 @@ GNU Affero General Public License for more details.
 	}
 	h4 {
 		margin: .5em;
+	}
+	@media (prefers-color-scheme: dark) {
+		body {
+			background: #191b22;
+		}
+		footer {
+			color: #aaa;
+		}
 	}
 </style>
 


### PR DESCRIPTION
React to the light mode with a bright background and dark footer text, to the dark mode with the prior design of a dark background and bright footer text. The form in the center of the page works well in both modes, so it wasn't changed.