### PR TITLE
makes border radius styling consistent

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@ GNU Affero General Public License for more details.
 		flex-direction: column;
 		gap: .8em;
 		background: #444b5d;
-		border-radius: 0;
+		border-radius: 4px;
 		padding: .8em;
 		max-width: 40rem;
 		margin-top: auto;


### PR DESCRIPTION
sets the border radius of the main element to be consistent with the styling elsewhere on the page as well as being consistent with mastodon UI

![image](https://github.com/Juerd/tootpick/assets/16740469/d694e85f-4742-43a3-b354-11a1e0ac027e)
